### PR TITLE
Optimize render instructions

### DIFF
--- a/implicitkernel/host_primitives.cpp
+++ b/implicitkernel/host_primitives.cpp
@@ -35,26 +35,25 @@ bool entities::simp_entity::simple() const
     return true;
 }
 
-void entities::simp_entity::render_data_size(size_t& nBytes, size_t& nEntities, size_t& nSteps) const
+void entities::simp_entity::render_data_size_internal(size_t& nBytes, size_t& nSteps, std::unordered_set<entity*>& simpleEntities) const
 {
     nBytes += num_render_bytes();
-    nEntities++;
+    simpleEntities.insert((entity*)this);
 }
 
-void entities::simp_entity::copy_render_data(
+void entities::simp_entity::copy_render_data_internal(
     uint8_t*& bytes, uint32_t*& offsets, uint8_t*& types, op_step*& steps, size_t& entityIndex,
-    size_t& currentOffset, std::optional<uint32_t> reg,
-    std::optional<std::unordered_map<entity*, uint32_t>> regMap) const
+    size_t& currentOffset, uint32_t reg,
+    std::unordered_map<entity*, uint32_t>& regMap) const
 {
-    if (!regMap.has_value()) regMap.emplace();
-    auto match = regMap->find((entity*)this);
-    if (match == regMap->end())
+    auto match = regMap.find((entity*)this);
+    if (match == regMap.end())
     {
         *(offsets++) = (uint32_t)currentOffset;
         currentOffset += num_render_bytes();
         write_render_bytes(bytes);
         *(types++) = type();
-        regMap->emplace((entity*)this, (uint32_t)entityIndex);
+        regMap.emplace((entity*)this, (uint32_t)entityIndex);
         entityIndex++;
     }
 }
@@ -79,24 +78,22 @@ uint8_t entities::comp_entity::type() const
     return ENT_TYPE_CSG;
 }
 
-void entities::comp_entity::render_data_size(size_t& nBytes, size_t& nEntities, size_t& nSteps) const
+void entities::comp_entity::render_data_size_internal(size_t& nBytes, size_t& nSteps, std::unordered_set<entities::entity*>& simpleEntities) const
 {
-    if (left) left->render_data_size(nBytes, nEntities, nSteps);
-    if (right) right->render_data_size(nBytes, nEntities, nSteps);
+    if (left) left->render_data_size_internal(nBytes, nSteps, simpleEntities);
+    if (right) right->render_data_size_internal(nBytes, nSteps, simpleEntities);
     nSteps++;
 }
 
-void entities::comp_entity::copy_render_data(
+void entities::comp_entity::copy_render_data_internal(
     uint8_t*& bytes, uint32_t*& offsets, uint8_t*& types, op_step*& steps,
-    size_t& entityIndex, size_t& currentOffset, std::optional<uint32_t> reg,
-    std::optional<std::unordered_map<entity*, uint32_t>> regMap) const
+    size_t& entityIndex, size_t& currentOffset, uint32_t regVal,
+    std::unordered_map<entity*, uint32_t>& regMap) const
 {
-    uint32_t regVal = reg.value_or(0);
-    if (!regMap.has_value()) regMap.emplace();
     bool lcsg = (left) ? !left->simple() : false;
     bool rcsg = (right) ? !right->simple() : false;
-    auto lmatch = lcsg ? regMap->end() : regMap->find(left.get());
-    auto rmatch = rcsg ? regMap->end() : regMap->find(right.get());
+    auto lmatch = lcsg ? regMap.end() : regMap.find(left.get());
+    auto rmatch = rcsg ? regMap.end() : regMap.find(right.get());
 
     if (regVal >= MAX_ENTITY_COUNT - 2)
     {
@@ -106,20 +103,20 @@ void entities::comp_entity::copy_render_data(
 
     uint32_t lsrc =
         lcsg ? regVal :
-        lmatch == regMap->end() ? (uint32_t)entityIndex :
+        lmatch == regMap.end() ? (uint32_t)entityIndex :
         lmatch->second;
 
     if (left)
-        left->copy_render_data(bytes, offsets, types, steps, entityIndex, currentOffset, regVal, regMap);
+        left->copy_render_data_internal(bytes, offsets, types, steps, entityIndex, currentOffset, regVal, regMap);
 
     uint32_t rsrc =
         (rcsg && lcsg) ? regVal + 1 :
         rcsg ? regVal :
-        rmatch == regMap->end() ? (uint32_t)entityIndex :
+        rmatch == regMap.end() ? (uint32_t)entityIndex :
         rmatch->second;
 
     if (right)
-        right->copy_render_data(bytes, offsets, types, steps, entityIndex, currentOffset, (lcsg && rcsg) ? (regVal + 1) : regVal, regMap);
+        right->copy_render_data_internal(bytes, offsets, types, steps, entityIndex, currentOffset, (lcsg && rcsg) ? (regVal + 1) : regVal, regMap);
 
     *(steps++) = {
         op,
@@ -244,4 +241,19 @@ void entities::halfspace::write_render_bytes(uint8_t*& bytes) const
     i_halfspace ient = { {origin.x, origin.y, origin.z} , {normal.x, normal.y, normal.z} };
     std::memcpy(bytes, &ient, sizeof(ient));
     bytes += sizeof(ient);
+}
+
+void entities::entity::render_data_size(size_t& nBytes, size_t& nEntities, size_t& nSteps) const
+{
+    std::unordered_set<entity*> simples;
+    render_data_size_internal(nBytes, nSteps, simples);
+    nEntities = simples.size();
+}
+
+void entities::entity::copy_render_data(uint8_t*& bytes, uint32_t*& offsets, uint8_t*& types, op_step*& steps) const
+{
+    size_t entityIndex = 0;
+    size_t currentOffset = 0;
+    std::unordered_map<entity*, uint32_t> regMap;
+    copy_render_data_internal(bytes, offsets, types, steps, entityIndex, currentOffset, 0, regMap);
 }

--- a/implicitkernel/include/host_primitives.h
+++ b/implicitkernel/include/host_primitives.h
@@ -64,7 +64,14 @@ namespace entities
          */
         virtual void render_data_size(size_t& nBytes, size_t& nEntities, size_t& nSteps) const;
 
-        virtual void render_data_size_internal(size_t& nBytes, size_t& nSteps, std::unordered_set<entity*>& simpleEntities) const = 0;
+        /**
+         * \brief Copies the render data into the given destination buffers.
+         * \param bytes The render data will be written to this buffer.
+         * \param offsets The byte offsets of the simple entities (in the above buffer).
+         * \param types The types of simple entities.
+         * \param steps The csg steps to be performed on the simple entities.
+         */
+        void copy_render_data(uint8_t*& bytes, uint32_t*& offsets, uint8_t*& types, op_step*& steps) const;
 
         /**
          * \brief Copies the render data into the given destination buffers.
@@ -81,7 +88,7 @@ namespace entities
             size_t& entityIndex, size_t& currentOffset, uint32_t reg,
             std::unordered_map<entity*, uint32_t>& regMap) const = 0;
 
-        void copy_render_data(uint8_t*& bytes, uint32_t*& offsets, uint8_t*& types, op_step*& steps) const;
+        virtual void render_data_size_internal(size_t& nBytes, size_t& nSteps, std::unordered_set<entity*>& simpleEntities) const = 0;
 
         /**
          * \brief Returns a reference to the copy of the given entity.

--- a/implicitkernel/include/host_primitives.h
+++ b/implicitkernel/include/host_primitives.h
@@ -76,7 +76,8 @@ namespace entities
          */
         virtual void copy_render_data(
             uint8_t*& bytes, uint32_t*& offsets, uint8_t*& types, op_step*& steps,
-            size_t& entityIndex, size_t& currentOffset, std::optional<uint32_t> reg = std::nullopt) const = 0;
+            size_t& entityIndex, size_t& currentOffset, std::optional<uint32_t> reg = std::nullopt,
+            std::optional<std::unordered_map<entity*, uint32_t>> regMap = std::nullopt) const = 0;
 
         /**
          * \brief Returns a reference to the copy of the given entity.
@@ -121,7 +122,8 @@ namespace entities
         virtual void render_data_size(size_t& nBytes, size_t& nEntities, size_t& nSteps) const;
         virtual void copy_render_data(
             uint8_t*& bytes, uint32_t*& offsets, uint8_t*& types, op_step*& steps,
-            size_t& entityIndex, size_t& currentOffset, std::optional<uint32_t> reg = std::nullopt) const;
+            size_t& entityIndex, size_t& currentOffset, std::optional<uint32_t> reg = std::nullopt,
+            std::optional<std::unordered_map<entity*, uint32_t>> regMap = std::nullopt) const;
 
         comp_entity(const comp_entity&) = delete;
         const comp_entity& operator=(const comp_entity&) = delete;
@@ -245,7 +247,8 @@ namespace entities
         virtual void write_render_bytes(uint8_t*& bytes) const = 0;
         virtual void copy_render_data(
             uint8_t*& bytes, uint32_t*& offsets, uint8_t*& types, op_step*& steps,
-            size_t& entityIndex, size_t& currentOffset, std::optional<uint32_t> reg = std::nullopt) const;
+            size_t& entityIndex, size_t& currentOffset, std::optional<uint32_t> reg = std::nullopt,
+            std::optional<std::unordered_map<entity*, uint32_t>> regMap = std::nullopt) const;
     };
 
     /**

--- a/implicitkernel/viewer.cpp
+++ b/implicitkernel/viewer.cpp
@@ -744,8 +744,7 @@ void viewer::show_entity(entities::ent_ref entity)
         uint32_t* optr = offsets.data();
         uint8_t* tptr = types.data();
         op_step* sptr = steps.data();
-        size_t ei = 0, co = 0;
-        entity->copy_render_data(bptr, optr, tptr, sptr, ei, co);
+        entity->copy_render_data(bptr, optr, tptr, sptr);
     }
 
     viewer::add_render_data(bytes.data(), nBytes, types.data(), offsets.data(), nEntities, steps.data(), nSteps);


### PR DESCRIPTION
Before this PR, the simple entities that are referenced multiple times were getting cloned all the time. This is not efficient for rendering. Now we use a unordered maps and sets to not repeat stuff. We don't hash the actual geometry but we just compare the pointers of entities.

Closes #9 